### PR TITLE
Update reference to latest path in bower dir

### DIFF
--- a/blueprints/ember-cli-flexibility/index.js
+++ b/blueprints/ember-cli-flexibility/index.js
@@ -6,6 +6,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('flexibility');
+    return this.addBowerPackageToProject('flexibility', '~2.0.1');
   }
 };

--- a/blueprints/ember-cli-flexibility/index.js
+++ b/blueprints/ember-cli-flexibility/index.js
@@ -6,6 +6,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('flexibility', '~2.0.1');
+    return this.addBowerPackageToProject('flexibility', '^2.0.1');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "flexibility": "^1.0.6"
+    "flexibility": "^2.0.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     delete this.options.enabled;
 
     if (this.enabled) {
-      app.import(app.bowerDirectory + '/flexibility/dist/flexibility.js');
+      app.import(app.bowerDirectory + '/flexibility/flexibility.js');
     }
   },
 


### PR DESCRIPTION
The latest version of flexibility doesn't have the _**flexibility.js**_ inside the **_dist_** folder. This commit takes care of the reference update. Might want to bump major version so that existing users don't get affected by this change.
