### PR TITLE
Guard for FastBoot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.12'
+- '6.10.2'
 sudo: false
 cache:
   directories:

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = {
     this.enabled = this.options.enabled;
     delete this.options.enabled;
 
-    if (this.enabled) {
+    if (this.enabled && !process.env.EMBER_CLI_FASTBOOT) {
       app.import(app.bowerDirectory + '/flexibility/flexibility.js');
     }
   },
@@ -37,5 +37,9 @@ module.exports = {
     }
 
     return tree;
+  },
+
+  isDevelopingAddon: function() {
+    return true;
   }
 };


### PR DESCRIPTION
This PR adds a guard so FastBoot builds don't break.

Fixes #2 